### PR TITLE
llama+mha: inject per-layer attention via factory and add MHAFactory

### DIFF
--- a/attn_arena/attention/base.py
+++ b/attn_arena/attention/base.py
@@ -29,6 +29,20 @@ class AttentionOutput:
 
 
 @runtime_checkable
+class AttentionFactory(Protocol):
+    """Factory for creating per-layer attention modules.
+
+    Backbones use this protocol to instantiate one attention module per
+    transformer layer, avoiding accidental parameter sharing across layers.
+    Implementations may return the same attention variant for every layer or
+    choose different variants/configurations based on `layer_idx`.
+    """
+
+    def create(self, layer_idx: int) -> AttentionModule:
+        """Create the attention module instance for `layer_idx`."""
+
+
+@runtime_checkable
 class KVCache(Protocol):
     """Variant-owned KV cache interface.
 

--- a/attn_arena/attention/mha.py
+++ b/attn_arena/attention/mha.py
@@ -241,3 +241,14 @@ class MultiHeadAttention(nn.Module):
         if tp_world_size == 1:
             return self
         raise NotImplementedError("Tensor parallel sharding is not implemented yet.")
+
+
+class MHAFactory:
+    """Create a fresh MHA module per layer to avoid parameter sharing."""
+
+    def __init__(self, config: LlamaConfig) -> None:
+        self.config = config
+
+    def create(self, layer_idx: int) -> AttentionModule:
+        _ = layer_idx
+        return MultiHeadAttention(self.config)

--- a/attn_arena/models/base.py
+++ b/attn_arena/models/base.py
@@ -4,14 +4,14 @@ from typing import Protocol, runtime_checkable
 
 import torch
 
-from attn_arena.attention.base import AttentionModule, KVCache
+from attn_arena.attention.base import AttentionFactory, KVCache
 
 
 @runtime_checkable
 class ModelBackbone(Protocol):
     """Backbone contract for decoder-only model families."""
 
-    def set_attention(self, attention: AttentionModule) -> None:
+    def set_attention(self, attention_factory: AttentionFactory) -> None:
         """Inject the attention implementation used by this backbone."""
 
     def get_rope_cos_sin(

--- a/attn_arena/models/llama/model.py
+++ b/attn_arena/models/llama/model.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from attn_arena.attention.base import AttentionModule, KVCache
+from attn_arena.attention.base import AttentionFactory, AttentionModule, KVCache
 from attn_arena.models.llama.config import LlamaConfig
 from attn_arena.models.registry import register_model
 
@@ -92,7 +94,7 @@ class LlamaBackbone(nn.Module):
         self.config = config
         self.vocab_size = config.vocab_size
         self.dim = config.dim
-        self.attention: AttentionModule | None = None
+        self.attention_factory: AttentionFactory | None = None
         self._rope_cache_len = 0
         self._rope_cos_cache: torch.Tensor | None = None
         self._rope_sin_cache: torch.Tensor | None = None
@@ -106,14 +108,14 @@ class LlamaBackbone(nn.Module):
         for _ in range(config.n_layers):
             self.layers.append(TransformerBlock(config))
 
-    def set_attention(self, attention: AttentionModule) -> None:
-        if self.attention is not None:
+    def set_attention(self, attention_factory: AttentionFactory) -> None:
+        if self.attention_factory is not None:
             raise ValueError("Attention already set on LlamaBackbone.")
 
-        self.attention = attention
-        for layer in self.layers:
+        self.attention_factory = attention_factory
+        for i, layer in enumerate(self.layers):
             assert isinstance(layer, TransformerBlock)
-            layer.set_attention(attention)
+            layer.set_attention(attention_factory.create(i))
 
     def get_rope_cos_sin(
         self,
@@ -148,7 +150,7 @@ class LlamaBackbone(nn.Module):
         sin = self._rope_sin_cache[position_ids]
         return cos.unsqueeze(2), sin.unsqueeze(2)
 
-    def shard(self, tp_rank: int, tp_world_size: int) -> "LlamaBackbone":
+    def shard(self, tp_rank: int, tp_world_size: int) -> LlamaBackbone:
         """Return a new model instance configured for tensor-parallel rank."""
         _ = tp_rank
         if tp_world_size == 1:
@@ -184,7 +186,7 @@ class LlamaBackbone(nn.Module):
         attention_mask: torch.Tensor | None = None,
         cache_position: torch.LongTensor | None = None,
     ) -> torch.Tensor:
-        if self.attention is None:
+        if self.attention_factory is None:
             raise ValueError("Attention must be set before calling forward.")
 
         batch_size, seq_len = input_ids.shape

--- a/tests/unit/test_llama_mha_smoke.py
+++ b/tests/unit/test_llama_mha_smoke.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import torch
 
-from attn_arena.attention.mha import MultiHeadAttention
+from attn_arena.attention.mha import MHAFactory, MultiHeadAttention
 from attn_arena.models.llama.config import LlamaConfig
-from attn_arena.models.llama.model import LlamaBackbone
+from attn_arena.models.llama.model import LlamaBackbone, TransformerBlock
 
 
 def _tiny_llama_config() -> LlamaConfig:
@@ -104,8 +104,18 @@ def test_mha_decode_grows_kv_cache() -> None:
 def test_llama_backbone_with_mha_smoke() -> None:
     config = _tiny_llama_config()
     model = LlamaBackbone(config)
-    attention = MultiHeadAttention(config)
-    model.set_attention(attention)
+    model.set_attention(MHAFactory(config))
+
+    layer0 = model.layers[0]
+    layer1 = model.layers[1]
+    assert isinstance(layer0, TransformerBlock)
+    assert isinstance(layer1, TransformerBlock)
+    assert layer0 is not layer1
+    assert layer0.attention is not None
+    assert layer1.attention is not None
+    assert isinstance(layer0.attention, MultiHeadAttention)
+    assert isinstance(layer1.attention, MultiHeadAttention)
+    assert layer0.attention.wq.weight.data_ptr() != layer1.attention.wq.weight.data_ptr()
 
     batch_size = 2
     seq_len = 5


### PR DESCRIPTION
## Summary

Refactors attention injection to be factory-based so each Transformer layer gets its own attention module instance (no parameter sharing across layers). This makes the Llama backbone compatible with real per-layer checkpoint weights and enables future per-layer attention policies (e.g., alternating sliding-window vs full attention).

## Problem

`LlamaBackbone.set_attention(...)` previously injected the same `nn.Module` attention instance into every layer, unintentionally tying attention weights across layers. This does not match Llama-style architectures and makes realistic checkpoint loading/remapping impractical.

## Implementation

- Add `AttentionFactory` protocol for per-layer attention creation: `attn_arena/attention/base.py`
- Update backbone contract to accept `AttentionFactory` in `set_attention(...)`: `attn_arena/models/base.py`
- Update Llama backbone to wire `attention_factory.create(layer_idx)` per layer and track initialization: `attn_arena/models/llama/model.py`
- Add `MHAFactory` that returns a fresh `MultiHeadAttention(config)` per layer: `attn_arena/attention/mha.py`
- Update smoke test to use `MHAFactory` and assert attention weights are not shared across layers: `tests/unit/test_llama_mha_smoke.py`

## Testing

```bash
uv run ruff check .
uv run ruff format --check .
uv run mypy attn_arena
uv run pytest tests/unit/test_llama_mha_smoke.py
uv run pytest -m "not gpu and not correctness"
All checks passed!
44 files already formatted
Success: no issues found in 34 source files
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.12.9, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/hamzaelshafie/Desktop/Cursor-Workplace/attn-arena
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.0.0
collected 3 items                                                                                                                                             

tests/unit/test_llama_mha_smoke.py ...                                                                                                                  [100%]

====================================================================== 3 passed in 0.75s ======================================================================
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.12.9, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/hamzaelshafie/Desktop/Cursor-Workplace/attn-arena
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.12.1, cov-7.0.0
collected 14 items                                                                                                                                            

tests/unit/test_attention_registry.py ....                                                                                                              [ 28%]
tests/unit/test_llama_mha_smoke.py ...                                                                                                                  [ 50%]
tests/unit/test_model_registry.py ....                                                                                                                  [ 78%]
tests/unit/test_protocol_contracts.py ...                                                                                                               [100%]

===================================================================== 14 passed in 0.44s ======================================================================
```

## Risks

- API change: `ModelBackbone.set_attention(...)` now requires an `AttentionFactory` rather than an `AttentionModule` instance; downstream callers must be updated, which they have been done.
- Any code relying on cross-layer parameter sharing (unlikely intentional) will change behavior.

## Follow-ups

- Add a minimal CPU inference runner (prefill + token-by-token decode using KV caches) and test functionality.
- Add FA2 backend selector for `mha` (guarded import + fallback to SDPA) while preserving mask semantics.
- Implement `gqa` as a separate attention variant leveraging `n_kv_heads`.

## Self-Review Checklist

- [x] Single-purpose PR with coherent scope.
- [ ] Branch name follows `<area>-<goal>`.
- [x] Public interfaces/types are explicit and documented.
- [x] No unrelated file changes included.
- [x] `ruff check .` passes.
- [x] `ruff format --check .` passes.
- [x] `mypy attn_arena` passes.
- [x] `pytest -m "not gpu and not correctness"` passes.
- [x] If behavior changed, tests were added/updated.
- [x] CI is green on latest commit.
